### PR TITLE
Improve auth error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,8 @@ gestionale-spese-famiglia/
 - **Login sicuro** con hashing bcrypt
 - **Sessioni JWT** gestite da NextAuth.js
 - **Protezione route** con middleware
-- **Gestione errori** auth centralizzata
+- **Gestione errori** auth centralizzata con pagina `/auth/error` che mostra
+  messaggi specifici per codici come `CredentialsSignin` o `AccessDenied`
 
 ### 👨‍👩‍👧‍👦 Gestione Famiglia
 - **Creazione famiglia** con nome personalizzato

--- a/app/auth/error/page.tsx
+++ b/app/auth/error/page.tsx
@@ -13,10 +13,18 @@ function AuthErrorContent() {
 
   const errorMessages: { [key: string]: string } = {
     CredentialsSignin: 'Invalid username or password. Please try again.',
+    AccessDenied: 'Access denied. Please contact the administrator.',
+    Configuration: 'Server configuration error. Please check server logs.',
+    Verification: 'The sign in link is no longer valid. Please sign in again.',
+    OAuthAccountNotLinked: 'Account not linked. Use the originally connected provider.',
+    OAuthCallback: 'OAuth callback failed. Please try again.',
+    OAuthCreateAccount: 'OAuth account creation failed. Please try again.',
+    EmailCreateAccount: 'Email account creation failed. Please try again.',
     default: 'An unexpected error occurred. Please try again.',
   }
 
-  const errorMessage = error && (errorMessages[error] || errorMessages.default)
+  const errorMessage =
+    error && (errorMessages[error] || `${errorMessages.default} (${error})`)
 
   return (
     <div className="flex items-center justify-center min-h-screen bg-gray-100">


### PR DESCRIPTION
## Summary
- show specific NextAuth error hints on `/auth/error`
- document new error messages in README

## Testing
- `npx jest --config jest.config.js` *(fails: aftereAll is not defined)*
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: tsx not found)*

------
https://chatgpt.com/codex/tasks/task_e_68821dacf594833395922832dd64512c