### PR TITLE
Fix docs for sqlite

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,8 +8,11 @@
 # -----------------------------------------------------------------------------
 # DATABASE CONFIGURATION
 # -----------------------------------------------------------------------------
-# Connessione database (PostgreSQL)
-DATABASE_URL="postgresql://username:password@host:5432/database?sslmode=require"
+# Connessione database (SQLite per sviluppo)
+DATABASE_URL="file:./dev.db"
+
+# Esempio per database PostgreSQL (produzione)
+# DATABASE_URL="postgresql://username:password@host:5432/database?sslmode=require"
 
 # -----------------------------------------------------------------------------
 # NEXTAUTH.JS AUTHENTICATION

--- a/README.md
+++ b/README.md
@@ -316,8 +316,8 @@ npm run dev
 
 #### Sviluppo Locale
 ```bash
-# Database (PostgreSQL)
-DATABASE_URL="postgresql://localhost:5432/dev_db"
+# Database (SQLite)
+DATABASE_URL="file:./dev.db"
 
 # NextAuth.js
 NEXTAUTH_URL="http://localhost:3000"

--- a/scripts/validate-env.ts
+++ b/scripts/validate-env.ts
@@ -3,12 +3,18 @@ import 'dotenv/config';
 
 // Schema di validazione per le variabili d'ambiente
 const envSchema = z.object({
-  DATABASE_URL: z.string().url().refine(
-    (url) => url.startsWith('postgresql://') || url.startsWith('postgres://'),
-    {
-      message: "DATABASE_URL must start with 'postgresql://' or 'postgres://'"
-    }
-  ),
+  DATABASE_URL: z
+    .string()
+    .refine(
+      (url) =>
+        url.startsWith('postgresql://') ||
+        url.startsWith('postgres://') ||
+        url.startsWith('file:'),
+      {
+        message:
+          "DATABASE_URL must start with 'postgresql://', 'postgres://' or 'file:'"
+      }
+    ),
   NEXTAUTH_URL: z.string().url(),
   NEXTAUTH_SECRET: z.string().min(30, {
     message: "NEXTAUTH_SECRET must be at least 30 characters long"


### PR DESCRIPTION
## Summary
- update README for SQLite default
- tweak .env.example for SQLite
- update env validation script for `file:` URLs

## Testing
- `npm run validate-env`
- `npm run lint` *(fails: prompts for setup)*

------
https://chatgpt.com/codex/tasks/task_e_68834466821c8333a21a60a53fd4a69b